### PR TITLE
Fix from_rel_data_map return

### DIFF
--- a/relativity/relativity.py
+++ b/relativity/relativity.py
@@ -424,7 +424,7 @@ class M2MGraph(object):
         rel_data_map -- { (lhs_col, rhs_col): {lhs_val: rhs_val} }
         """
         # TODO: better checking
-        cls(rel_data_map.keys(), rel_data_map)
+        return cls(rel_data_map.keys(), rel_data_map)
 
     def __getitem__(self, key):
         """

--- a/relativity/tests/test_basic.py
+++ b/relativity/tests/test_basic.py
@@ -172,3 +172,9 @@ def test_listeners():
     chk()
     test.discard(1, 1)
     chk()
+
+
+def test_from_rel_data_map_returns_graph():
+    rel_data_map = {('a', 'b'): M2M([(1, 2)]), ('b', 'c'): M2M([(2, 3)])}
+    g = M2MGraph.from_rel_data_map(rel_data_map)
+    assert isinstance(g, M2MGraph)


### PR DESCRIPTION
## Summary
- return the generated M2MGraph from `M2MGraph.from_rel_data_map`
- add regression test verifying the returned object type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4e4692708329b19f537117cea8c9