### PR TITLE
Add generic typing for M2M

### DIFF
--- a/relativity/star.py
+++ b/relativity/star.py
@@ -6,14 +6,15 @@ The underlying data structure is a list of M2Ms
 """
 import itertools
 
+from typing import Iterable, FrozenSet, Tuple, Any
 from relativity import M2M
 
 
-def star(*m2ms):
+def star(*m2ms: M2M) -> 'Star':
     return Star(m2ms, copy=False)
 
 class Star(object):
-    def __init__(self, m2ms, copy=True):
+    def __init__(self, m2ms: Iterable[M2M], copy: bool = True) -> None:
         # TODO: typecheck
         if m2ms.__class__ is self.__class__:
             m2ms = m2ms.m2ms
@@ -22,11 +23,11 @@ class Star(object):
         else:
             self.m2ms = m2ms
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> FrozenSet[Tuple[Any, ...]]:
         return frozenset(itertools.product(*[
             m2m.get(key) for m2m in self.m2ms]))
 
-    def __iter__(self):
+    def __iter__(self) -> Iterable[Tuple[Any, ...]]:
         keys = set()
         for m2m in self.m2ms:
             keys.update(m2m)

--- a/relativity/tree.py
+++ b/relativity/tree.py
@@ -1,3 +1,4 @@
+from typing import Any, Iterable, Iterator, Tuple
 from relativity import M2M
 
 
@@ -65,16 +66,16 @@ class M2MTree(object):
             else:
                 self.pair_counts[pair] -= 1
 
-    def __contains__(self, pair):
+    def __contains__(self, pair: Tuple[Any, Any]) -> bool:
         return pair in self.pair_counts
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Any) -> Any:
         return self.pairs[key]
 
-    def get(self, key):
+    def get(self, key: Any) -> Any:
         return self.pairs.get(key)
 
-    def iteritems(self):
+    def iteritems(self) -> Iterator[Tuple[Any, Any]]:
         return self.pairs.iteritems()
 
 
@@ -83,12 +84,12 @@ class TreeIndexer(object):
     manages construction and maintenance of trees
     """
     # TODO: can M2MGraph public API be extended to support this?
-    def __init__(self, pair_m2m_map):
+    def __init__(self, pair_m2m_map: dict) -> None:
         self.pair_m2m_map = pair_m2m_map
         self.tree_map = {}  # {(lhs, rhs): M2MTree}
         self.parents_of = {id(m2m): [] for m2m in pair_m2m_map.values()}
 
-    def add_index(self, *cols):
+    def add_index(self, *cols: Any) -> None:
         # this would synergize well with find_paths from M2MGraph
         pairs = tuple(zip(cols[:-1], cols[1:]))
         for pair in pairs:
@@ -96,7 +97,7 @@ class TreeIndexer(object):
         assert len(pairs) >= 2
         self._add_index2(pairs)
 
-    def _add_index2(self, pairs):
+    def _add_index2(self, pairs: Tuple[Tuple[Any, Any], ...]) -> M2MTree:
         cur_col_pair = (pairs[0][0], pairs[-1][1])
         if cur_col_pair in self:
             return self[cur_col_pair]
@@ -117,20 +118,20 @@ class TreeIndexer(object):
             self.parents_of[id(right)].append(ret)
         return ret
 
-    def notify_add(self, rel, a, b):
+    def notify_add(self, rel: Tuple[Any, Any], a: Any, b: Any) -> None:
         m2m = self.pair_m2m_map[rel]
         for parent in self.parents_of[id(m2m)]:
             parent.notify_add(m2m, a, b)
 
-    def notify_remove(self, rel, a, b):
+    def notify_remove(self, rel: Tuple[Any, Any], a: Any, b: Any) -> None:
         m2m = self.pair_m2m_map[rel]
         for parent in self.parents_of[id(m2m)]:
             parent.notify_remove(m2m, a, b)
 
-    def __getitem__(self, pair):
+    def __getitem__(self, pair: Tuple[Any, Any]) -> Any:
         if pair in self.pair_m2m_map:
             return self.pair_m2m_map[pair]
         return self.tree_map[pair]
 
-    def __contains__(self, pair):
+    def __contains__(self, pair: Tuple[Any, Any]) -> bool:
         return pair in self.pair_m2m_map or pair in self.tree_map


### PR DESCRIPTION
## Summary
- make `M2M` a generic mapping between key/value types
- define `inv` as the reverse `M2M[V, K]`
- update method signatures to use the generic parameters
- clarify purpose of type variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e824883208329a88306b9c0bce0fd