### PR TITLE
Implement full dict subclass for M2M

### DIFF
--- a/relativity/relativity.py
+++ b/relativity/relativity.py
@@ -63,15 +63,9 @@ class M2M(dict, Generic[K, V]):
         return frozenset(sofar)
 
     def pop(self, key: K) -> FrozenSet[V]:
-        vals = dict.pop(self, key)
-        for val in list(vals):
-            rev = dict.__getitem__(self.inv, val)
-            rev.remove(key)
-            if not rev:
-                del self.inv[val]
-            if self.listeners:
-                self._notify_remove(key, val)
-        return frozenset(vals)
+        val = frozenset(dict.__getitem__(self, key))
+        del self[key]
+        return val
 
     def __getitem__(self, key: K) -> FrozenSet[V]:
         return frozenset(dict.__getitem__(self, key))

--- a/relativity/relativity.py
+++ b/relativity/relativity.py
@@ -63,9 +63,15 @@ class M2M(dict, Generic[K, V]):
         return frozenset(sofar)
 
     def pop(self, key: K) -> FrozenSet[V]:
-        val = frozenset(dict.__getitem__(self, key))
-        del self[key]
-        return val
+        vals = dict.pop(self, key)
+        for val in list(vals):
+            rev = dict.__getitem__(self.inv, val)
+            rev.remove(key)
+            if not rev:
+                del self.inv[val]
+            if self.listeners:
+                self._notify_remove(key, val)
+        return frozenset(vals)
 
     def __getitem__(self, key: K) -> FrozenSet[V]:
         return frozenset(dict.__getitem__(self, key))
@@ -194,9 +200,7 @@ class M2M(dict, Generic[K, V]):
                 m2m[k] = []
         return m2m
 
-    def keys(self) -> Iterable[K]:
-        return dict.keys(self)
-
+    # dict.keys() already has the correct behavior
     def values(self) -> Iterable[V]:
         return self.inv.keys()
 


### PR DESCRIPTION
## Summary
- turn `M2M` into an actual `dict` subclass
- implement missing mapping methods (items, clear, popitem, setdefault, fromkeys)
- provide copy support and equality/inequality operations
- update `M2MChain` to use new copy helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e88ec9a588329a7e43eedcf3585f2