### PR TITLE
Fix docs and update Python support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ language: python
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27
-    - python: "3.5"
-      env: TOXENV=py35
-    - python: "3.7"
-      dist: xenial
-      env: TOXENV=py37
-    - python: "pypy"
+    - python: "3.10"
+      env: TOXENV=py310
+    - python: "3.11"
+      env: TOXENV=py311
+    - python: "pypy-3.10"
       env: TOXENV=pypy
-    - python: "2.7"
+    - python: "3.10"
       env: TOXENV=packaging
 
 

--- a/README.rst
+++ b/README.rst
@@ -471,7 +471,7 @@ Coming back to the students-and-classes example:
 Better Together
 """""""""""""""
 
-At a low-level, a Pandas_ ``Series`` and a Relaitivity ``M2M`` can
+At a low-level, a Pandas_ ``Series`` and a Relativity ``M2M`` can
 both represent multiple values per key, so it is easy to convert
 between the two.
 

--- a/relativity/__init__.py
+++ b/relativity/__init__.py
@@ -1,2 +1,3 @@
 
 from .relativity import M2M, M2MChain, M2MGraph, chain
+from .star import star, Star

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,8 @@ setup(name='relativity',
           'Topic :: Utilities',
           'Intended Audience :: Developers',
           'Topic :: Software Development :: Libraries',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy', ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py37,pypy,coverage-report,packaging
+envlist = py310,py311,pypy,coverage-report,packaging
 
 [testenv]
 changedir = .tox


### PR DESCRIPTION
## Summary
- correct README typo
- export `star` and `Star` from the package root
- drop obsolete Python versions from classifiers
- update CI and tox to test Python 3.10+

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8fdaaaf88329bc4ddeca9f996ec7