### PR TITLE
Simplify build metadata to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "relativity"
+version = "20.1.1dev"
+description = "Relational object sets."
+readme = "README.rst"
+license = {text = "MIT"}
+authors = [{name = "Kurt Rose", email = "kurt@kurtrose.com"}]
+requires-python = ">=3.10"
+classifiers = [
+    "Topic :: Utilities",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+
+[project.urls]
+Homepage = "https://github.com/kurtbrose/relativity"
+
+[tool.setuptools.packages.find]
+include = ["relativity", "relativity.tests"]
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 attrs
 boltons
 coverage
-pytest==4.*
+pytest>=7
 tox

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,24 @@
 from setuptools import setup
 
-
-__author__ = 'Kurt Rose'
-__version__ = '20.1.1dev'
-__contact__ = 'kurt@kurtrose.com'
-__url__ = 'https://github.com/kurtbrose/relativity'
-__license__ = 'MIT'
-
-
-with open('README.rst') as readme_f:
-    long_description = readme_f.read()
-
-
-setup(name='relativity',
-      version=__version__,
-      description="Relational object sets.",
-      long_description=long_description,
-      long_description_content_type='text/x-rst',
-      author=__author__,
-      author_email=__contact__,
-      url=__url__,
-      packages=['relativity', 'relativity.tests'],
-      include_package_data=True,
-      zip_safe=False,
-      license=__license__,
-      platforms='any',
-      classifiers=[
-          'Topic :: Utilities',
-          'Intended Audience :: Developers',
-          'Topic :: Software Development :: Libraries',
-          'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3.11',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Programming Language :: Python :: Implementation :: PyPy', ]
-)
-
+if __name__ == "__main__":
+    setup()
 
 """
 A brief checklist for release:
 
 * tox
 * git commit (if applicable)
-* Bump setup.py version off of -dev
+* Bump pyproject.toml version off of -dev
 * git commit -a -m "bump version for vx.y.z release"
 * rm -rf dist/*
-* python setup.py sdist bdist_wheel
+* python -m build
 * twine upload dist/*
 * bump docs/conf.py version
 * git commit
 * git tag -a vx.y.z -m "brief summary"
 * write CHANGELOG
 * git commit
-* bump setup.py version onto n+1 dev
+* bump pyproject.toml version onto n+1 dev
 * git commit
 * git push
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,10 @@ commands = coverage combine --rcfile {toxinidir}/.tox-coveragerc
 [testenv:packaging]
 changedir = {toxinidir}
 deps =
+   build
    twine
    check-manifest
 commands =
-   python setup.py sdist bdist_wheel
+   python -m build
    twine check dist/*
    check-manifest


### PR DESCRIPTION
## Summary
- move package options into `pyproject.toml`
- shrink `setup.py` to a stub and update release checklist

## Testing
- `pytest -q`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_687f6ba7d24c83299890e90873c601d9