### PR TITLE
Remove outdated TODO

### DIFF
--- a/relativity/tests/test_basic.py
+++ b/relativity/tests/test_basic.py
@@ -140,9 +140,6 @@ def test_m2mgraph_basic():
     assert ('a', 'c') in m2mg
 
 
-#TODO: test M2MGraph.add_rel
-
-
 def test_listeners():
     """
     test that listeners work okay by ensuring that


### PR DESCRIPTION
## Summary
- remove obsolete `M2MGraph.add_rel` todo from tests
- clean up spacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7d71f8148329befc3eae56d1f6d0