### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.10'
+            tox-env: py310
+          - python-version: '3.11'
+            tox-env: py311
+          - python-version: 'pypy-3.10'
+            tox-env: pypy
+          - python-version: '3.10'
+            tox-env: packaging
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+      - name: Run tox
+        run: tox -e ${{ matrix.tox-env }}


### PR DESCRIPTION
## Summary
- add simple GitHub Actions workflow to run `tox`

## Testing
- `tox -e py311`
- `tox -e packaging`

------
https://chatgpt.com/codex/tasks/task_e_687fdc0cb5d08329ae61320188a99103