### PR TITLE
Add error handling tests for M2MGraph.pairs

### DIFF
--- a/relativity/tests/test_basic.py
+++ b/relativity/tests/test_basic.py
@@ -1,5 +1,7 @@
 import copy
 
+import pytest
+
 
 from relativity import M2M, M2MChain, M2MGraph
 from relativity.tree import M2MTree
@@ -182,3 +184,15 @@ def test_from_rel_data_map_returns_graph():
     rel_data_map = {('a', 'b'): M2M([(1, 2)]), ('b', 'c'): M2M([(2, 3)])}
     g = M2MGraph.from_rel_data_map(rel_data_map)
     assert isinstance(g, M2MGraph)
+
+
+def test_m2mgraph_pairs_unknown_column_raises_keyerror():
+    g = M2MGraph([('a', 'b')])
+    with pytest.raises(KeyError):
+        g.pairs('a', 'c')
+
+
+def test_m2mgraph_pairs_no_path_raises_valueerror():
+    g = M2MGraph([('a', 'b'), ('c', 'd')])
+    with pytest.raises(ValueError):
+        g.pairs('a', 'd')


### PR DESCRIPTION
## Summary
- add `pytest` import in test_basic
- add tests ensuring `M2MGraph.pairs` raises `KeyError` when an invalid column
  is requested
- add tests ensuring `M2MGraph.pairs` raises `ValueError` when no path exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f7cb52448329af803920ce507b32