### PR TITLE
Fix replace_col validation and consolidate tests

### DIFF
--- a/relativity/relativity.py
+++ b/relativity/relativity.py
@@ -688,6 +688,18 @@ class M2MGraph(object):
         replace every value in col by the value in valmap
         raises KeyError if there is a value not in valmap
         """
+        current_vals = set()
+        for key in self.cols[col]:
+            if col == key[0]:
+                m2m = self.m2ms[key]
+            else:
+                m2m = self.m2ms[key].inv
+            current_vals.update(m2m.keys())
+
+        missing = current_vals - set(valmap)
+        if missing:
+            raise KeyError("missing mappings for values: {}".format(sorted(missing)))
+
         for key in self.cols[col]:
             if col == key[0]:
                 m2m = self.m2ms[key]

--- a/relativity/tests/test_basic.py
+++ b/relativity/tests/test_basic.py
@@ -196,3 +196,10 @@ def test_m2mgraph_pairs_no_path_raises_valueerror():
     g = M2MGraph([('a', 'b'), ('c', 'd')])
     with pytest.raises(ValueError):
         g.pairs('a', 'd')
+
+
+def test_replace_col_raises_keyerror_when_mapping_incomplete():
+    g = M2MGraph([('a', 'b')])
+    g['a', 'b'].update([(1, 2), (3, 4)])
+    with pytest.raises(KeyError):
+        g.replace_col('a', {1: 'x'})


### PR DESCRIPTION
## Summary
- enforce complete mapping when using `replace_col`
- consolidate new regression test into existing test module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880f9f8aebc8329a0c78faf125a01a5