### PR TITLE
Add TreeIndexer removal test

### DIFF
--- a/relativity/tests/test_tree.py
+++ b/relativity/tests/test_tree.py
@@ -18,3 +18,28 @@ def test():
                 continue
             assert set(idx[lhs, rhs].iteritems()) == set(
                 [(lhs + str(i), rhs + str(i)) for i in range(3)])
+
+
+def test_notify_remove_updates_pairs():
+    """TreeIndexer should drop pairs when underlying data is removed."""
+    idx = tree.TreeIndexer({('a', 'b'): M2M(), ('b', 'c'): M2M()})
+    idx.add_index('a', 'b', 'c')
+
+    # establish two paths through the tree
+    idx['a', 'b'].add('x', 'y')
+    idx.notify_add(('a', 'b'), 'x', 'y')
+    idx['b', 'c'].add('y', 'z')
+    idx.notify_add(('b', 'c'), 'y', 'z')
+
+    idx['a', 'b'].add('w', 'y')
+    idx.notify_add(('a', 'b'), 'w', 'y')
+
+    assert ('x', 'z') in idx['a', 'c']
+    assert ('w', 'z') in idx['a', 'c']
+
+    # remove one edge and notify the indexer
+    idx['a', 'b'].remove('x', 'y')
+    idx.notify_remove(('a', 'b'), 'x', 'y')
+
+    assert ('x', 'z') not in idx['a', 'c']
+    assert ('w', 'z') in idx['a', 'c']


### PR DESCRIPTION
## Summary
- add new test ensuring TreeIndexer pair removal updates indices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fcf893c48329b5d99e1914a31c05