### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ release = u'20.1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -299,4 +299,6 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}


### PR DESCRIPTION
## Summary
- specify english language for Sphinx
- fix `intersphinx_mapping` key for Sphinx 8 compatibility

## Testing
- `sphinx-build -b html docs docs/_build/html`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68897baaa5748329966c7dc2b0078fbc