### PR TITLE
Add simple indexing and query planning

### DIFF
--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -1,0 +1,57 @@
+import pytest
+
+from relativity.schema import Schema, Table, Eq
+
+
+class CountingExpr(Eq):
+    def __init__(self, base):
+        self.base = base
+        self.count = 0
+        super().__init__(base.left, base.right)
+
+    def eval(self, env):
+        self.count += 1
+        return super().eval(env)
+
+
+def test_index_updates_and_queries():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+        parent: str
+
+    expr = Student.parent == "p1"
+    schema.index(expr)
+
+    a = Student("a", "p1")
+    b = Student("b", "p2")
+    schema.add(a)
+    schema.add(b)
+    assert list(schema.all(Student).filter(expr)) == [a]
+
+    c = Student("c", "p1")
+    schema.add(c)
+    assert set(schema.all(Student).filter(expr)) == {a, c}
+
+    schema.remove(a)
+    assert list(schema.all(Student).filter(expr)) == [c]
+
+
+def test_query_planner_uses_index():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+
+    expr = CountingExpr(Student.name == "a")
+    schema.index(expr)
+    for n in ["a", "b", "c", "d"]:
+        schema.add(Student(n))
+    expr.count = 0
+    list(schema.all(Student).filter(expr))
+    assert expr.count == 0
+
+    expr2 = CountingExpr(Student.name == "a")
+    list(schema.all(Student).filter(expr2))
+    assert expr2.count == 4

--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -5,11 +5,11 @@ from relativity.schema import Schema, Table, Eq
 
 class CountingExpr(Eq):
     def __init__(self, base):
-        self.count = 0
+        object.__setattr__(self, "count", 0)
         super().__init__(base.left, base.right)
 
     def eval(self, env):
-        self.count += 1
+        object.__setattr__(self, "count", self.count + 1)
         return super().eval(env)
 
 


### PR DESCRIPTION
## Summary
- support creating and maintaining indexes via `Schema.index`
- add rudimentary query planner that uses available indexes when iterating row streams
- update schema on insert/delete to keep indexes in sync
- add tests covering index updates and planner usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a94164b4988329acab09a41ffb0789