### PR TITLE
Add replace helper and unique schema indices

### DIFF
--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -56,3 +56,15 @@ def test_query_planner_uses_index():
     expr2 = CountingExpr(Student.name == "a")
     list(schema.all(Student).filter(expr2))
     assert expr2.count == 0
+
+
+def test_unique_index_rejects_duplicate_add():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+
+    schema.index(Student.name, unique=True)
+    schema.add(Student("a"))
+    with pytest.raises(KeyError):
+        schema.add(Student("a"))

--- a/relativity/tests/test_schema.py
+++ b/relativity/tests/test_schema.py
@@ -88,3 +88,35 @@ def test_all_filter_and_alias():
     assert all(len(pair) == 2 for pair in pairs)
 
     assert list(schema.all(Student).filter(Student.parent == "p1")) == [a, c]
+
+
+def test_replace_swaps_fields_and_updates_index():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+
+    s = Student("a")
+    schema.add(s)
+    schema.index(Student.name, unique=True)
+
+    s2 = schema.replace(s, name="b")
+    assert s2.name == "b"
+    assert list(schema.all(Student)) == [s2]
+    assert list(schema.all(Student).filter(Student.name == "b")) == [s2]
+
+
+def test_replace_respects_unique_index():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+
+    schema.index(Student.name, unique=True)
+    a = Student("a")
+    b = Student("b")
+    schema.add(a)
+    schema.add(b)
+    with pytest.raises(KeyError):
+        schema.replace(a, name="b")
+    assert set(schema.all(Student)) == {a, b}


### PR DESCRIPTION
## Summary
- introduce an Index dataclass with optional unique flag and refactor schema indexing
- add Schema.replace helper built on remove/add operations
- enforce uniqueness constraints during add and replace and cover with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a94deaaaf083299dc8ed0ee9fc55d3