### PR TITLE
Add ordered index for inequality queries

### DIFF
--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -1,9 +1,19 @@
 import pytest
 
-from relativity.schema import Schema, Table, Eq
+from relativity.schema import Schema, Table, Eq, Gt
 
 
 class CountingExpr(Eq):
+    def __init__(self, base):
+        object.__setattr__(self, "count", 0)
+        super().__init__(base.left, base.right)
+
+    def eval(self, env):
+        object.__setattr__(self, "count", self.count + 1)
+        return super().eval(env)
+
+
+class CountingGt(Gt):
     def __init__(self, base):
         object.__setattr__(self, "count", 0)
         super().__init__(base.left, base.right)
@@ -68,3 +78,48 @@ def test_unique_index_rejects_duplicate_add():
     schema.add(Student("a"))
     with pytest.raises(KeyError):
         schema.add(Student("a"))
+
+
+def test_ordered_index_updates_and_queries():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+        score: int
+
+    schema.ordered_index(Student.score)
+
+    a = Student("a", 10)
+    b = Student("b", 20)
+    c = Student("c", 30)
+    for s in (a, b, c):
+        schema.add(s)
+
+    pred_gt = Student.score > 15
+    pred_lt = Student.score < 25
+    assert set(schema.all(Student).filter(pred_gt)) == {b, c}
+    assert set(schema.all(Student).filter(pred_lt)) == {a, b}
+
+    schema.remove(b)
+    assert list(schema.all(Student).filter(pred_gt)) == [c]
+
+
+def test_range_query_planner_uses_index():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+        score: int
+
+    for i in range(4):
+        schema.add(Student(str(i), i))
+
+    expr = CountingGt(Student.score > 1)
+    list(schema.all(Student).filter(expr))
+    assert expr.count == 4
+
+    schema.ordered_index(Student.score)
+
+    expr2 = CountingGt(Student.score > 1)
+    list(schema.all(Student).filter(expr2))
+    assert expr2.count == 0


### PR DESCRIPTION
## Summary
- support ordered indexes for totally ordered keys
- enable < and > filtering with new comparison expressions
- test ordered index behavior and planner optimization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a951a2bf7483298448d3da638ce440