### PR TITLE
Add deterministic ordering with tie-breaker and order_by

### DIFF
--- a/relativity/schema/index.py
+++ b/relativity/schema/index.py
@@ -15,7 +15,8 @@ class Index:
 
 @dataclass
 class OrderedIndex(Index):
-    keys: list[object] = field(default_factory=list)
+    data: dict[object, list[int]]
+    keys: list[tuple[object, int]] = field(default_factory=list)
 
 
 __all__ = ["Index", "OrderedIndex"]

--- a/relativity/schema/query.py
+++ b/relativity/schema/query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from bisect import bisect_left, bisect_right
 from itertools import product
 from typing import Iterable, Iterator, Sequence
+import sys
 
 from .expr import Expr, Eq, Lt, Le, Gt, Ge, _value
 from .index import OrderedIndex
@@ -12,13 +13,25 @@ if True:  # pragma: no cover - for type checking without runtime import
 
 
 class RowStream(Iterable[object]):
-    def __init__(self, schema: "Schema", tables: Sequence[type["Table"]], preds: Sequence[Expr] | None = None) -> None:
+    def __init__(
+        self,
+        schema: "Schema",
+        tables: Sequence[type["Table"]],
+        preds: Sequence[Expr] | None = None,
+        order: tuple[Expr, bool] | None = None,
+    ) -> None:
         self._schema = schema
         self._tables = list(tables)
         self._preds = list(preds or [])
+        self._order = order
 
     def filter(self, *exprs: Expr) -> "RowStream":
-        return RowStream(self._schema, self._tables, self._preds + list(exprs))
+        return RowStream(self._schema, self._tables, self._preds + list(exprs), self._order)
+
+    def order_by(self, key: Expr, id: bool = True) -> "RowStream":
+        if len(self._tables) != 1:
+            raise TypeError("order_by() requires exactly one table")
+        return RowStream(self._schema, self._tables, self._preds, (key, id))
 
     def __iter__(self) -> Iterator[object]:
         preds = list(self._preds)
@@ -38,8 +51,12 @@ class RowStream(Iterable[object]):
                             idx_base = getattr(tbl, "__table__", tbl)
                             if idx_base is base and not isinstance(other, Expr) and not isinstance(other, type):
                                 key = _value(other, {})
-                                bucket = rows.get(key, set())
-                                source = sorted(bucket, key=row_ids.__getitem__)
+                                if isinstance(idx, OrderedIndex):
+                                    ids = rows.get(key, [])
+                                    source = [self._schema._all_rows[i] for i in ids]
+                                else:
+                                    bucket = rows.get(key, set())
+                                    source = sorted(bucket, key=row_ids.__getitem__)
                                 preds.remove(pred)
                                 used = True
                                 break
@@ -59,23 +76,20 @@ class RowStream(Iterable[object]):
                         idx = self._schema._indices.get(expr)
                         if isinstance(idx, OrderedIndex) and not isinstance(other, Expr) and not isinstance(other, type):
                             key = _value(other, {})
-                            keys, rows = idx.keys, idx.data
+                            keys = idx.keys
                             if op == "<":
-                                pos = bisect_left(keys, key)
+                                pos = bisect_left(keys, (key, 0))
                                 sel = keys[:pos]
                             elif op == "<=":
-                                pos = bisect_right(keys, key)
+                                pos = bisect_right(keys, (key, sys.maxsize))
                                 sel = keys[:pos]
                             elif op == ">":
-                                pos = bisect_right(keys, key)
+                                pos = bisect_right(keys, (key, sys.maxsize))
                                 sel = keys[pos:]
                             else:  # >=
-                                pos = bisect_left(keys, key)
+                                pos = bisect_left(keys, (key, 0))
                                 sel = keys[pos:]
-                            bucket: list[object] = []
-                            for k in sel:
-                                bucket.extend(rows.get(k, set()))
-                            source = sorted(bucket, key=row_ids.__getitem__)
+                            source = [self._schema._all_rows[rid] for _, rid in sel]
                             preds.remove(pred)
                             used = True
                             break
@@ -93,10 +107,20 @@ class RowStream(Iterable[object]):
             if source is None:
                 source = sorted(self._schema._tables.get(base, set()), key=row_ids.__getitem__)
             sources.append(source)
+        results = []
         for combo in product(*sources):
             env = {t: r for t, r in zip(self._tables, combo)}
             if all(pred.eval(env) for pred in preds):
-                yield combo if len(combo) > 1 else combo[0]
+                results.append(combo if len(combo) > 1 else combo[0])
+        if self._order:
+            key_expr, use_id = self._order
+            tbl = self._tables[0]
+            def _sort_key(row: object):
+                val = key_expr.eval({tbl: row})
+                return (val, row_ids[row]) if use_id else val
+            results.sort(key=_sort_key)
+        for row in results:
+            yield row
 
 
 __all__ = ["RowStream"]

--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -97,8 +97,8 @@ def test_ordered_index_updates_and_queries():
 
     pred_gt = Student.score > 15
     pred_lt = Student.score < 25
-    assert set(schema.all(Student).filter(pred_gt)) == {b, c}
-    assert set(schema.all(Student).filter(pred_lt)) == {a, b}
+    assert list(schema.all(Student).filter(pred_gt)) == [b, c]
+    assert list(schema.all(Student).filter(pred_lt)) == [a, b]
 
     schema.remove(b)
     assert list(schema.all(Student).filter(pred_gt)) == [c]
@@ -159,4 +159,22 @@ def test_composite_ordered_index_range_queries():
         schema.add(s)
 
     pred = Tuple(Student.score, Student.name) >= (20, "b")
-    assert set(schema.all(Student).filter(pred)) == {b, c}
+    assert list(schema.all(Student).filter(pred)) == [b, c]
+
+
+def test_order_by_uses_tiebreaker():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+        score: int
+
+    schema.ordered_index(Student.score)
+
+    a = Student("a", 10)
+    b = Student("b", 10)
+    c = Student("c", 5)
+    for s in (a, b, c):
+        schema.add(s)
+
+    assert list(schema.all(Student).order_by(Student.score)) == [c, a, b]


### PR DESCRIPTION
## Summary
- Add row-id tie-breaker to ordered indexes for stable ordering
- Introduce `order_by` on `RowStream` and leverage ordered indexes
- Update tests for deterministic output and new ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a968e0e90883298a9c0f5182842c45