### PR TITLE
Normalize comparisons with new range expression

### DIFF
--- a/relativity/schema/__init__.py
+++ b/relativity/schema/__init__.py
@@ -1,5 +1,5 @@
 from .schema import Schema, Table, Ref, alias
-from .expr import Expr, Column, Tuple, Eq, Lt, Le, Gt, Ge, And, Or, Not
+from .expr import Expr, Column, Tuple, Eq, InRange, And, Or, Not
 from .index import Index, OrderedIndex
 from .query import RowStream
 
@@ -12,10 +12,7 @@ __all__ = [
     "Column",
     "Tuple",
     "Eq",
-    "Lt",
-    "Le",
-    "Gt",
-    "Ge",
+    "InRange",
     "And",
     "Or",
     "Not",


### PR DESCRIPTION
## Summary
- replace Lt/Le/Gt/Ge with a single `InRange` expression and handle negation by splitting into disjoint ranges
- update query planning to normalize and merge `InRange` bounds for ordered index scans
- adjust tests to use `InRange` comparison helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9705f86c08329acd8d1280e50f41c