### PR TITLE
feat: add partial and boolean covering indexes

### DIFF
--- a/relativity/schema/index.py
+++ b/relativity/schema/index.py
@@ -11,6 +11,7 @@ class Index:
     table: type["Table"]
     data: dict[object, set["Table"]]
     unique: bool = False
+    where: Expr | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- support partial indexes with optional `where` predicates
- use boolean predicate indexes for index-only filtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a97dff5b0c8329aca0dc20c86ce577