### PR TITLE
Optimize index storage and delta replace updates

### DIFF
--- a/relativity/schema/index.py
+++ b/relativity/schema/index.py
@@ -9,7 +9,7 @@ from .expr import Expr
 class Index:
     expr: Expr
     table: type["Table"]
-    data: dict[object, set["Table"]]
+    data: dict[object, set[int]]
     unique: bool = False
     where: Expr | None = None
 

--- a/relativity/schema/query.py
+++ b/relativity/schema/query.py
@@ -39,7 +39,6 @@ class EqScan(Scan):
     ordered: bool
 
     def run(self, s: "Schema", env: dict[type["Table"], object] | None = None) -> list[object]:
-        row_ids = s._row_ids
         idx = s._indices[self.index_expr]
         key_env = env or {}
         key = (
@@ -50,8 +49,8 @@ class EqScan(Scan):
         if self.ordered:
             ids = idx.data.get(key, [])
             return [s._all_rows[i] for i in ids]
-        bucket = idx.data.get(key, set())
-        return sorted(bucket, key=row_ids.__getitem__)
+        ids = sorted(idx.data.get(key, set()))
+        return [s._all_rows[i] for i in ids]
 
 
 @dataclass(frozen=True)
@@ -74,10 +73,9 @@ class BoolScan(Scan):
     index_expr: Expr
 
     def run(self, s: "Schema", env: dict[type["Table"], object] | None = None) -> list[object]:
-        row_ids = s._row_ids
         idx = s._indices[self.index_expr]
-        bucket = idx.data.get(True, set())
-        return sorted(bucket, key=row_ids.__getitem__)
+        ids = sorted(idx.data.get(True, set()))
+        return [s._all_rows[i] for i in ids]
 
 
 def _norm_one(pred: Expr) -> Expr:


### PR DESCRIPTION
## Summary
- Store row ids in indexes instead of row objects
- Update `replace` to compute old/new keys once and only modify changed buckets
- Adjust scans to resolve row ids back to rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9fcf24af88329aff534079793cf7e