### PR TITLE
Drop duplicate storage in OrderedIndex

### DIFF
--- a/relativity/schema/index.py
+++ b/relativity/schema/index.py
@@ -16,7 +16,7 @@ class Index:
 
 @dataclass
 class OrderedIndex(Index):
-    data: dict[object, list[int]]
+    data: dict[object, list[int]] = field(init=False, default_factory=dict)
     keys: list[tuple[object, int]] = field(default_factory=list)
 
 

--- a/relativity/schema/query.py
+++ b/relativity/schema/query.py
@@ -47,8 +47,10 @@ class EqScan(Scan):
             else _value(self.key, key_env)
         )
         if self.ordered:
-            ids = idx.data.get(key, [])
-            return [s._all_rows[i] for i in ids]
+            keys = idx.keys
+            lo = bisect_left(keys, (key, -1))
+            hi = bisect_right(keys, (key, sys.maxsize))
+            return [s._all_rows[rid] for _, rid in keys[lo:hi]]
         ids = sorted(idx.data.get(key, set()))
         return [s._all_rows[i] for i in ids]
 

--- a/relativity/tests/test_index.py
+++ b/relativity/tests/test_index.py
@@ -104,6 +104,26 @@ def test_ordered_index_updates_and_queries():
     assert list(schema.all(Student).filter(pred_gt)) == [c]
 
 
+def test_ordered_index_equality_queries():
+    schema = Schema()
+
+    class Student(schema.Table):
+        name: str
+        score: int
+
+    schema.ordered_index(Student.score)
+
+    a = Student("a", 10)
+    b = Student("b", 20)
+    c = Student("c", 10)
+    for s in (a, b, c):
+        schema.add(s)
+
+    expr = CountingExpr(Student.score == 10)
+    assert set(schema.all(Student).filter(expr)) == {a, c}
+    assert expr.count == 0
+
+
 def test_range_query_planner_uses_index():
     schema = Schema()
 


### PR DESCRIPTION
## Summary
- Remove duplicate key->id list storage from `OrderedIndex`, retaining only a sorted list of `(key, id)` pairs
- Use range slices on sorted keys for equality lookups instead of hash buckets
- Update schema operations and add tests for ordered index equality queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9fee413c88329979eb6daf242b2ac